### PR TITLE
Escape binary path to allow spaces in the path

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,4 +5,4 @@ module.exports = function (args, callback) {
   child_process.exec(module.exports.binaryPath + ' ' + args, callback)
 }
 
-module.exports.binaryPath = path.join(__dirname, 'sketchtool', 'bin', 'sketchtool')
+module.exports.binaryPath = path.join(__dirname, 'sketchtool', 'bin', 'sketchtool').replace(/ /g, '\\ ')


### PR DESCRIPTION
Had to add this fix to be able to use the package within the `Application Support` directory (more precise I'm trying to use sketchtool for my code testing setup within the Sketch plugin folder), so I thought it might be a helpful fix for others as well ;)